### PR TITLE
Remove "Sponsorship" link

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -18,7 +18,6 @@
           <li>{{#link-to "callforproposals"}}Call For Proposals{{/link-to}}</li>
           <li>{{#link-to "schedule"}}Schedule{{/link-to}}</li>
           <li>{{#link-to "sponsors"}}Sponsors{{/link-to}}</li>
-          <li>{{#link-to "sponsorship"}}Sponsorship{{/link-to}}</li>
           <li>{{#link-to "volunteer"}}Volunteer{{/link-to}}</li>
           <li>{{#link-to "codeofconduct"}}Code of Conduct{{/link-to}}</li>
           <li>


### PR DESCRIPTION
Removes the "Sponsorship" link from the nav.

How do we deploy?